### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Further reading:
 
 ## Installation
 
-You'll need [Cocoapods](http://cocoapods.org) for most of our dependencies.
+You'll need [CocoaPods](http://cocoapods.org) for most of our dependencies.
     
     $ gem install cocoapods
     
@@ -35,7 +35,7 @@ Now you'll need to build the dependencies.
     
 Open `ChatSecure.xcworkspace` in Xcode and build. 
 
-*Note*: **Don't open the `.xcodeproj`** because we're using Cocoapods.
+*Note*: **Don't open the `.xcodeproj`** because we're using CocoaPods.
 
 If you're still having trouble compiling check out the Travis-CI build status and `.travis.yml` file.
 


### PR DESCRIPTION

This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).
